### PR TITLE
Potential fix for code scanning alert no. 8: Use of externally-controlled format string

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -41,7 +41,7 @@ const getFileContent = (filePath) => {
         }
         return null;
     } catch (err) {
-        console.error(`Error reading file: ${filePath}`, err);
+        console.error('Error reading file: %s', filePath, err);
         return null;
     }
 };


### PR DESCRIPTION
Potential fix for [https://github.com/bquoctruong/gh-portfolio-pages/security/code-scanning/8](https://github.com/bquoctruong/gh-portfolio-pages/security/code-scanning/8)

To fix the problem, we need to ensure that the user-provided `filePath` is sanitized before being used in the format string. The best way to fix this is to use a `%s` specifier in the format string and pass the `filePath` as a corresponding argument. This approach ensures that the `filePath` is treated as a string and prevents any unexpected format specifiers from being processed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
